### PR TITLE
Fixed issue with using correctly sized image on iPhone 6 Plus screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pod 'Switch'
 Using Switch is quite simple :
 ```objective-c
 UIImage* image = [UIImage imageNamed:@"switch.png"];
-Switch* mySwitch = [Switch switchWithImage:image visibleWidth:200];
+Switch* mySwitch = [Switch switchWithImage:image visibleWidth:200 visibleWidthViewImageRatio:1];
 [mySwitch addTarget:self action:@selector(switchToggled:) forControlEvents:UIControlEventValueChanged];
 [self.view addSubview:mySwitch];
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Switch* mySwitch = [Switch switchWithImage:image visibleWidth:200 visibleWidthVi
 ```
 
 * Switch uses the image and visible width combination to toggle between states.
+* Use visibleWidthViewImageRatio = 1 if image visible width corresponds to the expected view width in pixels. Otherwise pass ratio calculated as [expected view width] / visibleWidth
 * You can provide cornerRadius of your choice to make it appear roundedCorner style or any other.
 
 ## What's the catch ?

--- a/Switch/Switch.h
+++ b/Switch/Switch.h
@@ -37,6 +37,8 @@ add -fobjc-arc flag for Switch.m file in Build Phases -> Compile Sources.
 //Width for switch frame, should always be less than the image's width
 @property(nonatomic,assign)CGFloat visibleWidth;
 
+@property(nonatomic,assign)CGFloat visibleWidthViewImageRatio;
+
 //Origin helps in positioning the switch, as width,height depend on image
 @property(nonatomic,assign)CGPoint origin;
 
@@ -46,8 +48,11 @@ add -fobjc-arc flag for Switch.m file in Build Phases -> Compile Sources.
 //ON-OFF toggle boolean
 @property(nonatomic,assign)BOOL on;
 
-//Class Helper to instantiate Switch with image & expected visibleWidth
+//Class Helper to instantiate Switch with image & expected visibleWidth of image.
+//  visibleWidthViewImageRatio is a ratio between expected switch view width
+//  and visible image width
 +(Switch*)switchWithImage:(UIImage*)switchImage
-             visibleWidth:(CGFloat)visibleWidth;
+             visibleWidth:(CGFloat)visibleWidth
+visibleWidthViewImageRatio:(CGFloat)visibleWidthViewImageRatio;
 
 @end

--- a/Switch/Switch.m
+++ b/Switch/Switch.m
@@ -23,7 +23,6 @@
  */
 
 #import "Switch.h"
-#define Scale [UIScreen mainScreen].scale
 
 @interface Switch()
 {
@@ -37,20 +36,22 @@
 
 +(Switch*)switchWithImage:(UIImage*)switchImage
              visibleWidth:(CGFloat)visibleWidth
+visibleWidthViewImageRatio:(CGFloat)visibleWidthViewImageRatio
 {
-    return [[self alloc] initSwitchWithImage:switchImage visibleWidth:visibleWidth];
+    return [[self alloc] initSwitchWithImage:switchImage visibleWidth:visibleWidth visibleWidthViewImageRatio:visibleWidthViewImageRatio];
 }
 
--(id)initSwitchWithImage:(UIImage*)switchImage visibleWidth:(CGFloat)visibleWidth
+-(id)initSwitchWithImage:(UIImage*)switchImage visibleWidth:(CGFloat)visibleWidth visibleWidthViewImageRatio:(CGFloat)visibleWidthViewImageRatio
 {
     if(self = [super init])
     {
         _image = switchImage;
         _visibleWidth = visibleWidth;
+        _visibleWidthViewImageRatio = visibleWidthViewImageRatio;
         _origin = CGPointZero;
         
         self.frame = CGRectMake(_origin.x, _origin.y,
-                                _visibleWidth, _image.size.height/Scale);
+                                _visibleWidth, self.visibleWidthViewImageRatio * _image.size.height);
         self.clipsToBounds = YES;
         
         imgVw = [[UIImageView alloc] initWithFrame:CGRectZero];
@@ -72,6 +73,19 @@
     return self;
 }
 
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    self.frame = CGRectMake(self.origin.x, self.origin.y, self.visibleWidthViewImageRatio * self.visibleWidth, self.visibleWidthViewImageRatio * self.image.size.height);
+    
+    imgVw.bounds = CGRectMake(0.f, 0.f,
+                              self.visibleWidthViewImageRatio * self.image.size.width,
+                              self.visibleWidthViewImageRatio * self.image.size.height);
+    imgVw.center = CGPointMake(self.on ? 0.5f * CGRectGetWidth(imgVw.bounds) : 0.f,
+                               0.5f * CGRectGetHeight(self.bounds));
+}
+
 #pragma mark
 #pragma mark<Property Setters>
 #pragma mark
@@ -79,27 +93,20 @@
 -(void)setVisibleWidth:(CGFloat)visibleWidth
 {
     _visibleWidth = visibleWidth;
-    
-    self.frame = CGRectMake(_origin.x, _origin.y, _visibleWidth, self.frame.size.height);
-    imgVw.frame = CGRectMake((_on ? 0 : -(_image.size.width/Scale - _visibleWidth)), 0,
-                             _image.size.width/Scale, _image.size.height/Scale);
+    [self setNeedsLayout];
 }
 
 -(void)setOrigin:(CGPoint)origin
 {
     _origin = origin;
-    
-    self.frame = CGRectMake(_origin.x, _origin.y, _visibleWidth, self.frame.size.height);
+    [self setNeedsLayout];
 }
 
 -(void)setImage:(UIImage*)image
 {
     _image = image;
-    
-    self.frame = CGRectMake(_origin.x, _origin.y, _visibleWidth, _image.size.height/Scale);
-    imgVw.frame = CGRectMake((_on ? 0 : -(_image.size.width/Scale - _visibleWidth)), 0,
-                             _image.size.width/Scale, _image.size.height/Scale);
     imgVw.image = _image;
+    [self setNeedsLayout];
 }
 
 #pragma mark
@@ -116,7 +123,7 @@
                      animations:^
      {
          self.userInteractionEnabled = NO;
-         imgVw.frame = CGRectMake((_on ? 0 : -(imgVw.frame.size.width-_visibleWidth)), 0,
+         imgVw.frame = CGRectMake((_on ? 0 : -(imgVw.frame.size.width-_visibleWidth * self.visibleWidthViewImageRatio)), 0,
                                   imgVw.frame.size.width,
                                   imgVw.frame.size.height);
      }


### PR DESCRIPTION
I faced a problem with switch control layout and logic working on iPhone 6 Plus screen. Had to add these corrections to get it working for all iPhone screen types as needed.
